### PR TITLE
Remove usage of codecov ATS

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,18 +17,11 @@ jobs:
         uses: eifinger/setup-rye@v3.0.2
       - name: Setup the environment
         run: rye sync --all-features
-      - name: Run ATS
-        uses: codecov/codecov-ats@v0.3.0
-        env:
-          CODECOV_STATIC_TOKEN: ${{ secrets.CODECOV_STATIC_TOKEN }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Run tests
-        run: cat codecov_ats/tests_to_run.txt | rye run pytest --cov=./ --cov-branch --cov-report=xml
+        run: rye run pytest --cov=./ --cov-branch --cov-report=xml
       - name: Upload coverage
         uses: codecov/codecov-action@v4.4.1
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          flags: smart-tests
-          plugins: pycoverage,compress-pycoverage
           fail_ci_if_error: true

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,23 +1,6 @@
-cli:
-  plugins:
-    pycoverage:
-      report_type: "xml"
 coverage:
   status:
     project:
       default:
         target: 0%
         threshold: 100%
-flag_management:
-  default_rules:
-    carryforward: true
-    statuses:
-      - type: project
-        target: 0%
-        threshold: 100%
-      - type: patch
-        target: 0%
-        threshold: 100%
-  individual_flags:
-    - name: smart-tests
-      carryforward_mode: "labels"


### PR DESCRIPTION
We are in the process of deprecating the ATS feature of codecov, and I saw you are one of the few (open source) users of it.